### PR TITLE
Add support for Symfony 7

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -20,7 +20,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sg_datatables');
         if (method_exists($treeBuilder, 'getRootNode')) {

--- a/Response/DatatableQueryBuilder.php
+++ b/Response/DatatableQueryBuilder.php
@@ -106,6 +106,13 @@ class DatatableQueryBuilder
     private $columns;
 
     /**
+     * All ColumnNames of the Datatable.
+     *
+     * @var array
+     */
+    private $columnNames;
+
+    /**
      * Contains all Columns to create a SELECT FROM statement.
      *
      * @var array

--- a/Tests/Response/DatatableQueryBuilderTest.php
+++ b/Tests/Response/DatatableQueryBuilderTest.php
@@ -12,7 +12,7 @@
 namespace Sg\DatatablesBundle\Tests\Response;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\Mapping\ClassMetadata;
@@ -87,7 +87,6 @@ final class DatatableQueryBuilderTest extends \PHPUnit\Framework\TestCase
         $entityName = '\App\Entity\Order';
         $shortName = 'Order';
         $this->queryBuilder->from($entityName, '_order')->willReturn($this->queryBuilder)->shouldBeCalled();
-
         $this->getDataTableQueryBuilder($entityName, $shortName);
     }
 
@@ -106,11 +105,12 @@ final class DatatableQueryBuilderTest extends \PHPUnit\Framework\TestCase
         $this->classMetadata->getReflectionClass()->willReturn($this->reflectionClass->reveal());
         $this->classMetadata->getIdentifierFieldNames()->willReturn([]);
         $this->classMetadataFactory->getMetadataFor($entityName)->willReturn($this->classMetadata->reveal());
-        $this->connection->getDatabasePlatform()->willReturn(new MySqlPlatform());
+        $this->connection->getDatabasePlatform()->willReturn(new MySQLPlatform());
         $this->entityManager->getMetadataFactory()->willReturn($this->classMetadataFactory->reveal());
         $this->entityManager->createQueryBuilder()->willReturn($this->queryBuilder->reveal());
         $this->entityManager->getConnection()->willreturn($this->connection->reveal());
         $this->columnBuilder->getColumns()->willReturn([]);
+        $this->columnBuilder->getColumnNames()->willReturn([]);
         $this->dataTable->getEntity()->willReturn($entityName);
         $this->dataTable->getEntityManager()->willReturn($this->entityManager->reveal());
         $this->dataTable->getColumnBuilder()->willReturn($this->columnBuilder->reveal());

--- a/composer.json
+++ b/composer.json
@@ -25,21 +25,22 @@
         "php": ">=7.2|>=8.0",
         "doctrine/orm": "^2.5",
         "friendsofsymfony/jsrouting-bundle": "^2.0|^3.0",
-        "symfony/config": "^4.4|^5.4|^6.0",
-        "symfony/dependency-injection": "^4.4|^5.4|^6.0",
-        "symfony/http-foundation": "^4.4|^5.4|^6.0",
-        "symfony/http-kernel": "^4.4|^5.4|^6.0",
-        "symfony/framework-bundle": "^4.4|^5.4|^6.0",
-        "symfony/options-resolver": "^4.4|^5.4|^6.0",
-        "symfony/property-access": "^4.4|^5.4|^6.0",
-        "symfony/routing": "^4.4|^5.4|^6.0",
-        "symfony/security-core": "^4.4|^5.4|^6.0",
-        "symfony/translation": "^4.4|^5.4|^6.0",
+        "symfony/config": "^4.4|^5.4|^6.0|^7.0",
+        "symfony/dependency-injection": "^4.4|^5.4|^6.0|^7.0",
+        "symfony/http-foundation": "^4.4|^5.4|^6.0|^7.0",
+        "symfony/http-kernel": "^4.4|^5.4|^6.0|^7.0",
+        "symfony/framework-bundle": "^4.4|^5.4|^6.0|^7.0",
+        "symfony/options-resolver": "^4.4|^5.4|^6.0|^7.0",
+        "symfony/property-access": "^4.4|^5.4|^6.0|^7.0",
+        "symfony/routing": "^4.4|^5.4|^6.0|^7.0",
+        "symfony/security-core": "^4.4|^5.4|^6.0|^7.0",
+        "symfony/translation": "^4.4|^5.4|^6.0|^7.0",
         "twig/twig": "^2.9|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.5",
-        "friendsofphp/php-cs-fixer": "^3.6"
+        "friendsofphp/php-cs-fixer": "^3.6",
+        "phpspec/prophecy": "^1.19"
     },
     "autoload": {
         "psr-4": { "Sg\\DatatablesBundle\\": "" }


### PR DESCRIPTION
Changes to enable support Symfony 7. 

Draft: It has not been fully tested yet, but in a project that heavily uses datatables it seemed to operate well after upgrading to Symfony 7. This upgrade was only a temporary tests, so it's not in production yet (thus I do not know for sure if some details cause issues)

Note that these changes are a bare minimum and no support for  `doctrine/orm` version 3 has been added yet as this probably would have a bigger impact.
A quick try with `"doctrine/orm": "^2.5|^3.0"` in composer showed errors in the unittests (that I could not fix in a minute), so this will at least require additional changes